### PR TITLE
fix(api): fix amount field renaming it to prevent misunderstanding

### DIFF
--- a/src/api/controllers/steam.controller.ts
+++ b/src/api/controllers/steam.controller.ts
@@ -51,14 +51,19 @@ export default {
     const {
       appId,
       category,
-      currency,
+      amount,
       itemDescription,
       itemId,
       orderId,
       steamId,
     }: ISteamOpenTransaction = <ISteamOpenTransaction>{ ...req.body };
 
-    if (!appId || !category || !currency || !itemDescription || !itemId || !orderId || !steamId) {
+    if (!amount) {
+      res.status(400).json({
+        error: 'Amount is a required field',
+      });
+      return;
+    } else if (!appId || !category || !itemDescription || !itemId || !orderId || !steamId) {
       res.status(400).json({
         error: 'Missing fields',
       });
@@ -69,7 +74,7 @@ export default {
       const data = await req.steam.steamMicrotransactionInitWithOneItem({
         appId,
         category,
-        currency,
+        amount,
         itemDescription,
         itemId,
         orderId,

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -85,9 +85,9 @@ export default (app: Express): void => {
      * @apiHeader {String} content-type application/json *required
      * 
      * @apiParam  (json) {String} appId string,
-     * @apiParam  (json) {String} orderId string,
-     * @apiParam  (json) {String} currency number, 
-     * @apiParam  (json) {Integer} itemId string,
+     * @apiParam  (json) {String} orderId number,
+     * @apiParam  (json) {String} amount number, 
+     * @apiParam  (json) {Integer} itemId number,
      * @apiParam  (json) {String} itemDescription string,
      * @apiParam  (json) {String} category string,
      * @apiParam  (json) {String} steamId User Steam ID
@@ -98,7 +98,7 @@ export default (app: Express): void => {
      * {
      *      appId: '480',
      *      orderId: '1',
-     *      currency: 199, 
+     *      amount: 199, 
      *      itemId: 11222,
      *      itemDescription: 'abcd',
      *      category: 'gold',

--- a/src/steam/steaminterfaces.ts
+++ b/src/steam/steaminterfaces.ts
@@ -28,7 +28,7 @@ export declare interface ISteamTransaction extends ISteamOrder {
 
 export declare interface ISteamOpenTransaction extends ISteamUserRequest {
   orderId: string;
-  currency: number;
+  amount: number;
   itemId: string;
   itemDescription: string;
   category: string;

--- a/src/steam/steamrequest.ts
+++ b/src/steam/steamrequest.ts
@@ -94,7 +94,7 @@ export default class SteamRequest {
       usersession: 'client',
       'itemid[0]': _transaction.itemId,
       'qty[0]': 1,
-      'amount[0]': _transaction.currency + constants.currency,
+      'amount[0]': _transaction.amount + constants.currency,
       'description[0]': _transaction.itemDescription,
       'category[0]': _transaction.category,
     };

--- a/tests/endpoint-init-purchase.test.ts
+++ b/tests/endpoint-init-purchase.test.ts
@@ -14,9 +14,9 @@ import microTxInitTransactionSuccessMock from './mock/micro-tx-init-transaction-
 describe('Controller Test: /InitPurchase', () => {
   const body = {
     appId: '480',
-    orderId: '1',
-    currency: 199,
-    itemId: 'abc',
+    orderId: 1000,
+    amount: 199,
+    itemId: 100,
     itemDescription: 'abcd',
     category: 'gold',
     steamId: VALID_USER_STEAM_ID,


### PR DESCRIPTION
This PR just renames the field currency to amount preventing confusion about the name and purpose.