### PR TITLE
Add coroutine for Steam callbacks

### DIFF
--- a/examples/unity/Microtransaction.cs
+++ b/examples/unity/Microtransaction.cs
@@ -19,12 +19,17 @@ public class Microtransaction : MonoBehaviour
     private bool _isInPurchaseProcess = false;
     private int currentCoins = 100;
 
-    // Unity Awake function    
-    private void Awake() 
+    // Unity Awake function
+    private void Awake()
     {
         // initialize the callback to receive after the purchase
-        m_MicroTxnAuthorizationResponse = Callback<MicroTxnAuthorizationResponse_t>.Create(OnMicroTxnAuthorizationResponse); 
+        m_MicroTxnAuthorizationResponse = Callback<MicroTxnAuthorizationResponse_t>.Create(OnMicroTxnAuthorizationResponse);
         currentOrder += Random.Range(1000000, 100000000);
+    }
+
+    private void Start()
+    {
+        StartCoroutine(ProcessCallbacks());
     }
 
     void OnGUI()
@@ -119,6 +124,15 @@ public class Microtransaction : MonoBehaviour
                     Debug.LogError("Error from API: " + ret.error);
                 }
             }
+        }
+    }
+
+    private IEnumerator ProcessCallbacks()
+    {
+        while (true)
+        {
+            SteamAPI.RunCallbacks();
+            yield return new WaitForSeconds(0.5f);
         }
     }
 

--- a/examples/unity/README.md
+++ b/examples/unity/README.md
@@ -3,3 +3,5 @@
 Just paste this folder inside the Unity and put Microtransaction.cs into any GameObject and press play
 
 Dont forget to install http://steamworks.github.io/ to use this script
+
+This script starts a `ProcessCallbacks` coroutine in `Start()` which runs `SteamAPI.RunCallbacks()` every half second. Ensure this coroutine is running so Steam callbacks are processed.


### PR DESCRIPTION
## Summary
- run `SteamAPI.RunCallbacks()` with `ProcessCallbacks` coroutine
- start the coroutine in the Unity example
- mention running callbacks in Unity README