### PR TITLE
Update docs base url placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ To prevent users from sending arbitrary amounts for products, there is a file ca
 ## INTEGRATING WITH YOUR GAME
 
 You can check the documentation of this API here: [https://jasielmacedo.github.io/steam-microtransaction-api/](https://jasielmacedo.github.io/steam-microtransaction-api/)
+Note that this site is static and does not provide a live API endpoint.
 
 The flow is as follows:
 

--- a/apidoc.json
+++ b/apidoc.json
@@ -3,5 +3,5 @@
     "version": "1.0.0",
     "description": "An intermediate api to handle steam microtransactions using steam web services.",
     "title": "Steam Microtransaction Intermediate API",
-    "url" : "http://127.0.0.1:3000"
+    "url" : "http://<your-api-url>"
   }

--- a/docs/api_project.js
+++ b/docs/api_project.js
@@ -3,7 +3,7 @@ define({
   "version": "1.0.0",
   "description": "An intermediate api to handle steam microtransactions using steam web services.",
   "title": "Steam Microtransaction Intermediate API",
-  "url": "http://127.0.0.1:3000",
+  "url": "http://<your-api-url>",
   "sampleUrl": false,
   "defaultVersion": "0.0.0",
   "apidoc": "0.3.0",

--- a/docs/api_project.json
+++ b/docs/api_project.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "An intermediate api to handle steam microtransactions using steam web services.",
   "title": "Steam Microtransaction Intermediate API",
-  "url": "http://127.0.0.1:3000",
+  "url": "http://<your-api-url>",
   "sampleUrl": false,
   "defaultVersion": "0.0.0",
   "apidoc": "0.3.0",


### PR DESCRIPTION
## Summary
- replace localhost URL in `apidoc.json`
- refresh generated docs with placeholder URL
- clarify in README that the documentation site is static

## Testing
- `yarn test`