### PR TITLE
Fix sessions for user startup and auth

### DIFF
--- a/server/app/api/models/user.py
+++ b/server/app/api/models/user.py
@@ -45,6 +45,12 @@ class User(Base):
         return result.scalar_one_or_none()
 
     @classmethod
+    async def get_by_api_key(cls, session: AsyncSession, api_key: str):
+        stmt = select(cls).where(cls.api_key == api_key)
+        result = await session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    @classmethod
     async def create(cls, session: AsyncSession, user_data: dict):
         hashed_password = pwd_context.hash(user_data["password"])
         user = cls(

--- a/server/app/core/init_data.py
+++ b/server/app/core/init_data.py
@@ -2,8 +2,10 @@ import logging
 import asyncio
 from typing import Dict, Any
 
+from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.models.user import User, UserRole
 from app.core.config import settings
+from app.db.sqlite import AsyncSessionLocal
 
 logger = logging.getLogger(__name__)
 
@@ -11,37 +13,42 @@ logger = logging.getLogger(__name__)
 async def create_admin_user() -> Dict[str, Any]:
     """Create admin user if it doesn't exist."""
     try:
-        # Check if admin user already exists
-        admin = await User.get_by_email(settings.ADMIN_EMAIL)
-        if admin is not None:
-            logger.info(f"Admin user already exists with email: {settings.ADMIN_EMAIL}")
-            return admin
-        
-        # Create admin user
-        admin_data = {
-            "name": settings.ADMIN_NAME,
-            "email": settings.ADMIN_EMAIL,
-            "password": settings.ADMIN_PASSWORD,
-            "role": UserRole.ADMIN,
-        }
-        
-        admin = await User.create(admin_data)
-        
-        # Generate API key for admin
-        api_key = await User.generate_api_key(admin["_id"])
-        
-        logger.info(f"Admin user created with email: {settings.ADMIN_EMAIL} and API key: {api_key}")
-        
-        # Warning about default credentials
-        if (
-            settings.ADMIN_EMAIL == "admin@example.com"
-            and settings.ADMIN_PASSWORD == "adminPassword123"
-        ):
-            logger.warning(
-                "Default admin credentials are being used. Change them immediately in production!"
+        async with AsyncSessionLocal() as session:
+            # Check if admin user already exists
+            admin = await User.get_by_email(session, settings.ADMIN_EMAIL)
+            if admin is not None:
+                logger.info(
+                    f"Admin user already exists with email: {settings.ADMIN_EMAIL}"
+                )
+                return admin
+
+            # Create admin user
+            admin_data = {
+                "name": settings.ADMIN_NAME,
+                "email": settings.ADMIN_EMAIL,
+                "password": settings.ADMIN_PASSWORD,
+                "role": UserRole.ADMIN,
+            }
+
+            admin = await User.create(session, admin_data)
+
+            # Generate API key for admin
+            api_key = await User.generate_api_key(session, admin.id)
+
+            logger.info(
+                f"Admin user created with email: {settings.ADMIN_EMAIL} and API key: {api_key}"
             )
-        
-        return admin
+
+            # Warning about default credentials
+            if (
+                settings.ADMIN_EMAIL == "admin@example.com"
+                and settings.ADMIN_PASSWORD == "adminPassword123"
+            ):
+                logger.warning(
+                    "Default admin credentials are being used. Change them immediately in production!"
+                )
+
+            return admin
     except Exception as e:
         logger.error(f"Error creating admin user: {str(e)}")
         # Don't raise to allow startup to continue

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -8,7 +8,7 @@ import logging
 from app.api.routes import api_router
 from app.core.config import settings
 from app.core.exceptions import BaseAPIException
-from app.db.sqlite import connect_to_db, close_db
+from app.db.sqlite import connect_to_db, close_db, AsyncSessionLocal
 from app.core.init_data import init_data
 from app.utils.notifications import NotificationManager
 from app.utils.notifications.email_provider import EmailNotificationProvider
@@ -68,7 +68,8 @@ async def startup_db_client():
         # Get notification settings from the database (admin settings)
         from app.api.models.settings import Settings as SettingsModel
         admin_id = settings.ADMIN_EMAIL  # Use admin email as team_id for now
-        app_settings = await SettingsModel.get_by_team_id(admin_id)
+        async with AsyncSessionLocal() as session:
+            app_settings = await SettingsModel.get_by_team_id(session, admin_id)
         
         # Configure notification providers from settings
         if app_settings and "notificationProviders" in app_settings:


### PR DESCRIPTION
## Summary
- fix DB session usage in `create_admin_user`
- wire session dependency into authentication endpoints
- ensure admin and team controllers use sessions
- add API key lookup helper on `User`
- use DB session when loading settings on startup
- update security helpers to accept DB session

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684492674648832ca07b9b38c2f1ce99