### PR TITLE
Add steam_app_id field to products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ typings/
 dist
 
 **/.claude/settings.local.json
+microtrax.db

--- a/server/app/api/models/product.py
+++ b/server/app/api/models/product.py
@@ -19,6 +19,7 @@ class Product(Base):
     type = Column(String, nullable=False)
     active = Column(Boolean, default=True)
     game_id = Column(String, nullable=True)
+    steam_app_id = Column(String, nullable=True)
     steam_item_id = Column(Integer, nullable=True)
     product_metadata = Column(JSON, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)

--- a/server/app/db/sqlite.py
+++ b/server/app/db/sqlite.py
@@ -26,6 +26,16 @@ async def connect_to_db():
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
         logger.info("Tables created successfully")
+
+        # Handle optional migrations
+        try:
+            result = await conn.execute(text("PRAGMA table_info(products);"))
+            columns = [row[1] for row in result.fetchall()]
+            if "steam_app_id" not in columns:
+                logger.info("Adding steam_app_id column to products table")
+                await conn.execute(text("ALTER TABLE products ADD COLUMN steam_app_id VARCHAR"))
+        except Exception as e:
+            logger.error(f"Error checking/updating products table: {e}")
     
     # Verify tables were created
     async with engine.connect() as conn:

--- a/server/tests/test_product_model.py
+++ b/server/tests/test_product_model.py
@@ -1,0 +1,21 @@
+import pytest
+import app.db.sqlite as db
+from app.api.models.product import Product
+
+@pytest.mark.asyncio
+async def test_create_product_with_steam_app_id(tmp_path):
+    await db.connect_to_db()
+    async with db.AsyncSessionLocal() as session:
+        data = {
+            "name": "Test Product",
+            "description": "Test Desc",
+            "price_cents": 100,
+            "type": "Currency",
+            "steam_app_id": "123",
+        }
+        product = await Product.create(session, data)
+        assert product.steam_app_id == "123"
+        fetched = await Product.get_by_id(session, product.id)
+        assert fetched.steam_app_id == "123"
+        await Product.delete(session, product.id)
+


### PR DESCRIPTION
## Summary
- include `steam_app_id` on Product model
- handle optional DB migration for the new column
- add regression test to save product with `steam_app_id`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c1533e50832cbe31f779b177bd28