### PR TITLE
Add ApiKey model and endpoints

### DIFF
--- a/server/app/api/controllers/apikey.py
+++ b/server/app/api/controllers/apikey.py
@@ -1,0 +1,92 @@
+from typing import Dict, Any
+
+from fastapi import Depends, status, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.models.apikey import ApiKey
+from app.db.sqlite import async_session
+from app.core.security import get_current_user
+from app.schemas.apikey import (
+    ApiKeyCreate,
+    ApiKeyListResponse,
+    ApiKeyCreateResponse,
+    ApiKeyRotateResponse,
+    ApiKeyDeleteResponse,
+    ApiKeyResponse,
+    ApiKeyFullResponse,
+)
+
+
+async def list_api_keys(
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    session: AsyncSession = Depends(async_session),
+):
+    """List API keys for the current user."""
+    keys = await ApiKey.get_by_user(session, current_user["id"])
+    key_responses = [
+        ApiKeyResponse(
+            id=k.id,
+            name=k.name,
+            prefix=k.prefix,
+            created_at=k.created_at,
+            last_used=k.last_used,
+        )
+        for k in keys
+    ]
+    return ApiKeyListResponse(data=key_responses)
+
+
+async def create_api_key(
+    key_data: ApiKeyCreate,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    session: AsyncSession = Depends(async_session),
+):
+    """Create a new API key and return the plain key."""
+    key, plain = await ApiKey.create(
+        session, current_user["id"], key_data.name, key_data.prefix
+    )
+    key_response = ApiKeyFullResponse(
+        id=key.id,
+        name=key.name,
+        prefix=key.prefix,
+        created_at=key.created_at,
+        last_used=key.last_used,
+        key=plain,
+    )
+    return ApiKeyCreateResponse(data=key_response)
+
+
+async def rotate_api_key(
+    key_id: str,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    session: AsyncSession = Depends(async_session),
+):
+    """Rotate an existing API key and return the new key."""
+    try:
+        key, plain = await ApiKey.rotate(session, key_id, current_user["id"])
+    except Exception as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+    key_response = ApiKeyFullResponse(
+        id=key.id,
+        name=key.name,
+        prefix=key.prefix,
+        created_at=key.created_at,
+        last_used=key.last_used,
+        key=plain,
+    )
+    return ApiKeyRotateResponse(data=key_response)
+
+
+async def delete_api_key(
+    key_id: str,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+    session: AsyncSession = Depends(async_session),
+):
+    """Delete an API key."""
+    try:
+        await ApiKey.delete(session, key_id, current_user["id"])
+    except Exception as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+    return ApiKeyDeleteResponse()

--- a/server/app/api/models/__init__.py
+++ b/server/app/api/models/__init__.py
@@ -4,6 +4,7 @@ from app.api.models.game import Game
 from app.api.models.product import Product
 from app.api.models.transaction import Transaction
 from app.api.models.settings import Settings
+from app.api.models.apikey import ApiKey
 
 __all__ = [
     "User",
@@ -12,4 +13,5 @@ __all__ = [
     "Product",
     "Transaction",
     "Settings",
+    "ApiKey",
 ]

--- a/server/app/api/models/apikey.py
+++ b/server/app/api/models/apikey.py
@@ -1,0 +1,85 @@
+import uuid
+from datetime import datetime
+
+from passlib.context import CryptContext
+from sqlalchemy import Column, String, DateTime
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.db.sqlite import Base
+from app.core.exceptions import NotFoundException
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+class ApiKey(Base):
+    __tablename__ = "api_keys"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    name = Column(String, nullable=False)
+    prefix = Column(String, nullable=False)
+    hashed_key = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    last_used = Column(DateTime, nullable=True)
+    user_id = Column(String, nullable=False, index=True)
+
+    @classmethod
+    async def get_by_user(cls, session: AsyncSession, user_id: str):
+        stmt = select(cls).where(cls.user_id == user_id)
+        result = await session.execute(stmt)
+        return result.scalars().all()
+
+    @classmethod
+    async def get_by_id(cls, session: AsyncSession, key_id: str, user_id: str):
+        stmt = select(cls).where(cls.id == key_id, cls.user_id == user_id)
+        result = await session.execute(stmt)
+        key = result.scalar_one_or_none()
+        if not key:
+            raise NotFoundException("API key not found")
+        return key
+
+    @classmethod
+    async def create(
+        cls, session: AsyncSession, user_id: str, name: str, prefix: str
+    ) -> tuple["ApiKey", str]:
+        import secrets
+        import string
+
+        alphabet = string.ascii_letters + string.digits
+        secret = "".join(secrets.choice(alphabet) for _ in range(32))
+        plain_key = f"{prefix}{secret}"
+        hashed = pwd_context.hash(plain_key)
+
+        key = cls(
+            name=name,
+            prefix=prefix,
+            hashed_key=hashed,
+            user_id=user_id,
+        )
+        session.add(key)
+        await session.commit()
+        await session.refresh(key)
+        return key, plain_key
+
+    @classmethod
+    async def rotate(
+        cls, session: AsyncSession, key_id: str, user_id: str
+    ) -> tuple["ApiKey", str]:
+        import secrets
+        import string
+
+        key = await cls.get_by_id(session, key_id, user_id)
+        alphabet = string.ascii_letters + string.digits
+        secret = "".join(secrets.choice(alphabet) for _ in range(32))
+        plain_key = f"{key.prefix}{secret}"
+        key.hashed_key = pwd_context.hash(plain_key)
+        key.last_used = None
+        await session.commit()
+        await session.refresh(key)
+        return key, plain_key
+
+    @classmethod
+    async def delete(cls, session: AsyncSession, key_id: str, user_id: str) -> bool:
+        key = await cls.get_by_id(session, key_id, user_id)
+        await session.delete(key)
+        await session.commit()
+        return True

--- a/server/app/api/routes/__init__.py
+++ b/server/app/api/routes/__init__.py
@@ -11,6 +11,7 @@ from app.api.routes.currency import router as currency_router
 from app.api.routes.export import router as export_router
 from app.api.routes.settings import router as settings_router
 from app.api.routes.game_client import router as game_client_router
+from app.api.routes.apikey import router as apikey_router
 
 # Create main API router
 api_router = APIRouter()
@@ -26,4 +27,5 @@ api_router.include_router(export_router, prefix="/admin", tags=["Export"])
 api_router.include_router(settings_router, prefix="/admin", tags=["Settings"])
 api_router.include_router(product_router, prefix="/products", tags=["Products"])
 api_router.include_router(game_client_router, prefix="/game-client", tags=["Game Client"])
+api_router.include_router(apikey_router, prefix="/api-keys", tags=["API Keys"])
 api_router.include_router(steam_router, prefix="", tags=["Steam"])

--- a/server/app/api/routes/apikey.py
+++ b/server/app/api/routes/apikey.py
@@ -1,0 +1,51 @@
+from fastapi import APIRouter, Depends
+
+from app.api.controllers.apikey import (
+    list_api_keys,
+    create_api_key,
+    rotate_api_key,
+    delete_api_key,
+)
+from app.core.security import get_current_user
+from app.schemas.apikey import (
+    ApiKeyListResponse,
+    ApiKeyCreateResponse,
+    ApiKeyRotateResponse,
+    ApiKeyDeleteResponse,
+    ApiKeyCreate,
+)
+
+router = APIRouter(dependencies=[Depends(get_current_user)])
+
+router.add_api_route(
+    "",
+    list_api_keys,
+    methods=["GET"],
+    response_model=ApiKeyListResponse,
+    summary="List API keys",
+)
+
+router.add_api_route(
+    "",
+    create_api_key,
+    methods=["POST"],
+    response_model=ApiKeyCreateResponse,
+    status_code=201,
+    summary="Create API key",
+)
+
+router.add_api_route(
+    "/{key_id}/rotate",
+    rotate_api_key,
+    methods=["POST"],
+    response_model=ApiKeyRotateResponse,
+    summary="Rotate API key",
+)
+
+router.add_api_route(
+    "/{key_id}",
+    delete_api_key,
+    methods=["DELETE"],
+    response_model=ApiKeyDeleteResponse,
+    summary="Delete API key",
+)

--- a/server/app/db/init_db.py
+++ b/server/app/db/init_db.py
@@ -12,7 +12,8 @@ def import_all_models():
             Game,
             Product,
             Transaction,
-            Settings
+            Settings,
+            ApiKey,
         )
         
         logger.info("All models imported successfully")


### PR DESCRIPTION
## Summary
- add ApiKey SQLAlchemy model
- add API key controllers and routes
- register new `/api-keys` router
- import ApiKey in model initialization and db init

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c14ea1d4832cbce3da338dbd8d15